### PR TITLE
fix Company datatypes

### DIFF
--- a/src/InfusionSoft/Tables/Company.cs
+++ b/src/InfusionSoft/Tables/Company.cs
@@ -169,7 +169,7 @@ namespace InfusionSoft.Tables
 
         [XmlRpcMember("LastUpdated")]
         [Access(Access.Read)]
-        public string LastUpdated { get; set; }
+        public DateTime LastUpdated { get; set; }
 
         [XmlRpcMember("LastUpdatedBy")]
         [Access(Access.Read)]


### PR DESCRIPTION
I was getting errors when using DataService.Query<Company>() to get a list of companies.

Error: response contains implicit X value where X expected

This fixed it.
