### PR TITLE
fixed Contact.CompanyID field

### DIFF
--- a/src/InfusionSoft/Tables/Contact.cs
+++ b/src/InfusionSoft/Tables/Contact.cs
@@ -124,7 +124,7 @@ namespace InfusionSoft.Tables
 
         [XmlRpcMember("CompanyID")]
         [Access(Access.Edit | Access.Delete | Access.Add | Access.Read)]
-        public int CompanyId { get; set; }
+        public int CompanyID { get; set; }
 
         [XmlRpcMember("ContactNotes")]
         [Access(Access.Edit | Access.Delete | Access.Add | Access.Read)]


### PR DESCRIPTION
I was getting errors about CompanyId field not existing when creating a contact. Changing to "CompanyID" fixed it.
