### PR TITLE
Fixed property types to reflect what Infusionsoft is sending

### DIFF
--- a/src/InfusionSoft/Tables/CCharge.cs
+++ b/src/InfusionSoft/Tables/CCharge.cs
@@ -28,11 +28,11 @@ namespace InfusionSoft.Tables
 
         [XmlRpcMember("PaymentId")]
         [Access(Access.Read)]
-        public string PaymentId { get; set; }
+        public int PaymentId { get; set; }
 
         [XmlRpcMember("MerchantId")]
         [Access(Access.Read)]
-        public string MerchantId { get; set; }
+        public int MerchantId { get; set; }
 
         [XmlRpcMember("OrderNum")]
         [Access(Access.Read)]

--- a/src/InfusionSoft/Tables/Invoice.cs
+++ b/src/InfusionSoft/Tables/Invoice.cs
@@ -89,6 +89,6 @@ namespace InfusionSoft.Tables
 
         [XmlRpcMember("Synced")]
         [Access(Access.Read)]
-        public int Synced { get; set; }
+        public bool Synced { get; set; }
     }
 }

--- a/src/InfusionSoft/Tables/InvoicePayment.cs
+++ b/src/InfusionSoft/Tables/InvoicePayment.cs
@@ -11,6 +11,7 @@
 
 #endregion
 
+using System;
 using CookComputing.XmlRpc;
 
 namespace InfusionSoft.Tables
@@ -32,7 +33,7 @@ namespace InfusionSoft.Tables
 
         [XmlRpcMember("PayDate")]
         [Access(Access.Read)]
-        public string PayDate { get; set; }
+        public DateTime PayDate { get; set; }
 
         [XmlRpcMember("PayStatus")]
         [Access(Access.Read)]

--- a/src/InfusionSoft/Tables/Payment.cs
+++ b/src/InfusionSoft/Tables/Payment.cs
@@ -11,6 +11,7 @@
 
 #endregion
 
+using System;
 using CookComputing.XmlRpc;
 
 namespace InfusionSoft.Tables
@@ -24,7 +25,7 @@ namespace InfusionSoft.Tables
 
         [XmlRpcMember("PayDate")]
         [Access(Access.Read)]
-        public string PayDate { get; set; }
+        public DateTime PayDate { get; set; }
 
         [XmlRpcMember("UserId")]
         [Access(Access.Read)]
@@ -64,6 +65,6 @@ namespace InfusionSoft.Tables
 
         [XmlRpcMember("Synced")]
         [Access(Access.Read)]
-        public int Synced { get; set; }
+        public bool Synced { get; set; }
     }
 }


### PR DESCRIPTION
Found some issues while working with the code.

```
var invoice = infusionsoft.DataService.Query<Invoice>(q => q.Add(o => o.JobId, 123));
var invoicePayment = infusionsoft.DataService.Query<InvoicePayment>(q => q.Add(o => o.InvoiceId, invoice.Id));
var payment = infusionsoft.DataService.Query<Payment>(q => q.Add(o => o.Id, invoicePayment.PaymentId));
var charge = infusionsoft.DataService.Query<CCharge>(q => q.Add(o => o.PaymentId, payment.Id));
```
