### PR TITLE
Fix for query expressions on properties with names differing from Infusi...

### DIFF
--- a/src/InfusionSoft/InfusionSoft.csproj
+++ b/src/InfusionSoft/InfusionSoft.csproj
@@ -201,6 +201,7 @@
     <Compile Include="Support\QueryBuilder.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Support\QueryBuilderExtensions.cs" />
     <Compile Include="Support\Serialization\XmlRpcDeserializer.cs" />
     <Compile Include="Support\Serialization\XmlRpcResponseDeserializer.cs" />
     <Compile Include="Support\StartsWithValue.cs">

--- a/src/InfusionSoft/Support/QueryBuilder.cs
+++ b/src/InfusionSoft/Support/QueryBuilder.cs
@@ -40,7 +40,7 @@ namespace InfusionSoft
         public IQueryBuilder<T> Add<TV>(Expression<Func<T, TV>> expression, TV value, ValuePosition valuePosition)
         {
             string name = Express.PropertyWithLambda(expression).Name;
-
+            name = this.GetColumnName(name);
             _dictionary.Add(name, BuildPositionalValue(valuePosition, value));
 
             return this;

--- a/src/InfusionSoft/Support/QueryBuilderExtensions.cs
+++ b/src/InfusionSoft/Support/QueryBuilderExtensions.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using CookComputing.XmlRpc;
+using InfusionSoft.Tables;
+
+namespace InfusionSoft
+{
+    internal static class QueryBuilderExtensions
+    {
+        private static Dictionary<Type, Dictionary<string, string>> _columnNames;
+        private static Dictionary<Type, Dictionary<string, string>> ColumnNames
+        {
+            get
+            {
+                return _columnNames ?? (_columnNames = new Dictionary<Type, Dictionary<string, string>>());
+            }
+        }
+        public static string GetColumnName<T>(this IQueryBuilder<T> builder, string propertyName) where T : ITable
+        {
+            if (!ColumnNames.ContainsKey(typeof(T)))
+            {
+                ColumnNames[typeof(T)] = new Dictionary<string, string>();
+                typeof(T).GetProperties()
+                    .Where(p => !p.Name.Equals("CustomFields") && !p.Name.EndsWith("Comparer"))
+                    .ToList()
+                    .ForEach(p =>
+                    {
+                        var attributes = p.GetCustomAttributes(typeof(XmlRpcMemberAttribute), false);
+                        if (!attributes.Any())
+                            return;
+                        var attribute = attributes.Cast<XmlRpcMemberAttribute>().First();
+                        if (!String.IsNullOrEmpty(attribute.Member) && attribute.Member != p.Name)
+                        {
+                            ColumnNames[typeof(T)].Add(p.Name, attribute.Member);
+                        }
+                    });
+            }
+            return ColumnNames[typeof(T)].ContainsKey(propertyName) ? _columnNames[typeof(T)][propertyName] : propertyName;
+        }
+    }
+}


### PR DESCRIPTION
Fix to allow LINQ expressions to query on properties whose names don't match InfusionSoft's corresponding table column name. Added QueryBuilderExtensions class, added property name lookup to QueryBuilder.Add method implementation.
