### PR TITLE
Add SendEmail method without optional param templateId

### DIFF
--- a/src/InfusionSoft/Definition/IEmailServiceDefinition.cs
+++ b/src/InfusionSoft/Definition/IEmailServiceDefinition.cs
@@ -47,6 +47,10 @@ namespace InfusionSoft.Definition
                        string bccAddresses, string contentType, string subject, string htmlBody, string textBody,
                        int templateId);
 
+        [XmlRpcMethod("APIEmailService.sendEmail")]
+        bool SendEmail(string apiKey, int[] contactList, string fromAddress, string toAddress, string ccAddresses,
+                       string bccAddresses, string contentType, string subject, string htmlBody, string textBody);
+
         [XmlRpcMethod("APIEmailService.sendTemplate")]
         bool SendTemplate(string apiKey, int[] contactList, string templateId);
 

--- a/src/InfusionSoft/IEmailService.cs
+++ b/src/InfusionSoft/IEmailService.cs
@@ -46,6 +46,8 @@ namespace InfusionSoft
         bool OptOut(string email, string optOutreason);
         
         bool SendEmail(int[] contactList, string fromAddress, string toAddress, string ccAddresses, string bccAddresses, string contentType, string subject, string htmlBody, string textBody, int templateId);
+
+        bool SendEmail(int[] contactList, string fromAddress, string toAddress, string ccAddresses, string bccAddresses, string contentType, string subject, string htmlBody, string textBody);
         
         bool SendTemplate(int[] contactList, string templateId);
         

--- a/src/InfusionSoft/Wrappers/EmailServiceWrapper.cs
+++ b/src/InfusionSoft/Wrappers/EmailServiceWrapper.cs
@@ -74,6 +74,11 @@ namespace InfusionSoft
         {
             return Invoke(d => d.SendEmail(ApiKey, contactList, fromAddress, toAddress, ccAddresses, bccAddresses, contentType, subject, htmlBody, textBody, templateId));
         }
+
+        public virtual bool SendEmail(int[] contactList, string fromAddress, string toAddress, string ccAddresses, string bccAddresses, string contentType, string subject, string htmlBody, string textBody)
+        {
+            return Invoke(d => d.SendEmail(ApiKey, contactList, fromAddress, toAddress, ccAddresses, bccAddresses, contentType, subject, htmlBody, textBody));
+        }
         
         public virtual bool SendTemplate(int[] contactList, string templateId)
         {


### PR DESCRIPTION
This fix: "Server returned a fault exception: [0] No method matching arguments: java.lang.String, [Ljava.lang.Object;, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.Integer" when you try to send email without a template. As a templetId I used 0 (zero).