### PR TITLE
Update InfusionSoftException to include InnerException

### DIFF
--- a/src/InfusionSoft/InfusionSoftException.cs
+++ b/src/InfusionSoft/InfusionSoftException.cs
@@ -19,7 +19,7 @@ namespace InfusionSoft
     [Serializable]
     public class InfusionSoftException : ApplicationException
     {
-        public InfusionSoftException(XmlRpcException e) : base(e.Message)
+        public InfusionSoftException(XmlRpcException e) : base(e.Message, e)
         {
         }
 

--- a/src/InfusionSoft/InfusionSoftException.cs
+++ b/src/InfusionSoft/InfusionSoftException.cs
@@ -22,6 +22,10 @@ namespace InfusionSoft
         public InfusionSoftException(XmlRpcException e) : base(e.Message, e)
         {
         }
+        
+        public InfusionSoftException(XmlRpcFaultException e) : base(e.Message, e)
+        {
+        }
 
         public InfusionSoftException(string message) : base(message)
         {

--- a/src/InfusionSoft/ServiceBase.cs
+++ b/src/InfusionSoft/ServiceBase.cs
@@ -58,7 +58,7 @@ namespace InfusionSoft
             }
             catch (XmlRpcFaultException e)
             {
-                throw new InfusionSoftException(e.Message);
+                throw new InfusionSoftException(e);
             }
         }
 


### PR DESCRIPTION
Update InfusionSoftException to include InnerException when it is initialised with a XmlRpcFaultException or XmlRpcException.

This allows the calling code to determine the FaultCode if required to isolate the error returned from Infusionsoft rather than parsing / regex on the exception message itself.